### PR TITLE
Removed unexistent wsdl argument from calls to Process.__init__()

### DIFF
--- a/processes/buffer.py
+++ b/processes/buffer.py
@@ -22,7 +22,6 @@ class Buffer(Process):
             title="Brauni's 1st process",
             abstract='This process is the best ever being coded',
             profile='',
-            wsdl='',
             metadata=['Process', '1st', 'Hilarious'],
             inputs=inputs,
             outputs=outputs,

--- a/processes/feature_count.py
+++ b/processes/feature_count.py
@@ -13,7 +13,6 @@ class FeatureCount(Process):
             title='Feature count',
             abstract='This process counts the number of features in a vector',
             profile='',
-            wsdl='',
             metadata=['Feature', 'Count'],
             inputs=inputs,
             outputs=outputs,

--- a/processes/sleep.py
+++ b/processes/sleep.py
@@ -13,7 +13,6 @@ class Sleep(Process):
             title='Sleep Process',
             abstract='This process will sleep for a given delay or 10 seconds if not a valid value',
             profile='',
-            wsdl='',
             metadata=['Sleep', 'Wait', 'Delay'],
             inputs=inputs,
             outputs=outputs,

--- a/processes/ultimate_question.py
+++ b/processes/ultimate_question.py
@@ -13,7 +13,6 @@ class UltimateQuestion(Process):
             title='Answer to the ultimate question',
             abstract='This process gives the answer to the ultimate question of "What is the meaning of life?',
             profile='',
-            wsdl='',
             metadata=['Ultimate Question', 'What is the meaning of life'],
             inputs=inputs,
             outputs=outputs,


### PR DESCRIPTION
A few process still had this argument when calling super.
